### PR TITLE
Initial device polling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Supported features at the moment:
 
 - ON
 - OFF
-- TOGGLE
+- TOGGLE (currently not used in the remote-software app)
 - BRIGHTNESS
 - COLOR
 - COLORTEMP
@@ -74,7 +74,7 @@ Note: COLORTEMP is not yet supported in the UI afaik.
 
 - ON
 - OFF
-- TOGGLE
+- TOGGLE (currently not used in the remote-software app)
 
 Initial response mapping is implemented with support for the power attribute.
 
@@ -99,6 +99,7 @@ Initial response mapping is implemented with support for the power attribute.
 
 - [x] Response mapping  
   E.g. entity attributes like brightness etc.
+  - [ ] Parsing color value strings
 - [x] Status polling
 - [x] Blind entity
   - [x] Invert position option
@@ -138,3 +139,8 @@ Add a `webhook` configuration inside `integrations`:
 ```
 
 See [setup-example.json](setup-example.json) for an example `integrations.webhook.data.data` section.
+
+### Configuration Examples
+
+- [myStrom Switch](doc/mystrom_switch.json)
+- [Shelly 2.5 roller shutter](doc/shelly_2.5_roller_shutter.json)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Work in progress!
 It may crash at any time, leak memory, or render your YIO remote unresponsive.  
 The json configuration is not finalized and will most likely change!
 
-This repository might be included in the official YIO project, once basic features are implemented and the configuration is stable.  
-Until then the web-configurator is unsupported, it might partially work, or not at all.
+This repository might be included in the official YIO project in the future, once basic features are implemented and the configuration is stable.
+
+The web-configurator is unsupported, it might partially work, or not at all.
 
 ## Features
 
@@ -41,6 +42,10 @@ Supported features at the moment:
 - Response mapping of Json payload with a simplified JsonPath syntax.
   - Nested values: `foo.bar.x`
   - Array index: `foo.bars[2].y`
+- Optional device status polling
+  - Enabled with entity command named `STATUS_POLLING`
+  - Only active while screen is on (non-standby)
+  - Polling intervall is configurable. Default: 30s
 
 ## Entity Support
 
@@ -90,6 +95,7 @@ Initial response mapping is implemented with support for the power attribute.
 - CLOSE
 - STOP
 - POSITION
+  - Position can be inverted with `attributes.invert_posiion: true`
 
 #### Placeholders
 
@@ -106,6 +112,8 @@ Initial response mapping is implemented with support for the power attribute.
 - [ ] Remote entity
 - [ ] Climate entity
 - [ ] Media player entity
+- [ ] Full documentation
+- [ ] Support MQTT?
 
 ## Configuration
 
@@ -142,5 +150,9 @@ See [setup-example.json](setup-example.json) for an example `integrations.webhoo
 
 ### Configuration Examples
 
+Verified configuration examples:
 - [myStrom Switch](doc/mystrom_switch.json)
 - [Shelly 2.5 roller shutter](doc/shelly_2.5_roller_shutter.json)
+
+Do you have other working configurations you'd like to share?
+Please send them by email, GitHub issue or pull request and I will add it to the list.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Initial response mapping is implemented with support for the power attribute.
 
 - [x] Response mapping  
   E.g. entity attributes like brightness etc.
-- [ ] Status polling
+- [x] Status polling
 - [x] Blind entity
   - [x] Invert position option
 - [ ] Remote entity

--- a/doc/mystrom_switch.json
+++ b/doc/mystrom_switch.json
@@ -11,7 +11,7 @@
                 "ON": "/relay?state=1",
                 "OFF": "/relay?state=0",
                 "TOGGLE": "/toggle",
-                "wh-STATUS": {
+                "STATUS_POLLING": {
                     "url": "/report",
                     "response" : {
                         "mappings": {

--- a/doc/mystrom_switch.json
+++ b/doc/mystrom_switch.json
@@ -1,0 +1,28 @@
+{
+    "_comment": "Example configuration for myStrom switch in config.json section: integrations.webhook.data[n].data",
+    "base_url": "http://192.168.100.200",
+    "status_polling": 30,
+    "entities": {
+        "switch" : [
+        {
+            "entity_id": "webhook.switch.1",
+            "friendly_name": "myStrom Switch",
+            "commands": {
+                "ON": "/relay?state=1",
+                "OFF": "/relay?state=0",
+                "TOGGLE": "/toggle",
+                "wh-STATUS": {
+                    "url": "/report",
+                    "response" : {
+                        "mappings": {
+                            "state_bool": ".relay",
+                            "power": ".power",
+                            "temperature_c": ".temperature"
+                        }
+                    }
+                }
+            }
+        }
+        ]
+    }
+}

--- a/doc/shelly_2.5_roller_shutter.json
+++ b/doc/shelly_2.5_roller_shutter.json
@@ -1,0 +1,38 @@
+{
+    "_comment": "Example configuration for Shelly 2.5 roller shutter in config.json section: integrations.webhook.data[n].data",
+    "base_url": "http://admin:admin@192.168.100.200/roller/0",
+    "status_polling": 30,
+    "entities": {
+        "blind" : [
+        {
+            "entity_id": "webhook.blind.1",
+            "friendly_name": "Shelly 2.5 roller shutter",
+            "attributes": {
+                "invert_position": true
+            },
+            "commands": {
+                "OPEN": {
+                    "url": "?go=open"
+                },
+                "CLOSE": {
+                    "url": "?go=close"
+                },
+                "STOP": {
+                    "url": "?go=stop"
+                },
+                "POSITION": {
+                    "url": "?go=to_pos&roller_pos=${position_percent}"
+                },
+                "wh-STATUS": {
+                    "url": "",
+                    "response" : {
+                        "mappings": {
+                            "position_percent": ".current_pos"
+                        }
+                    }
+                }
+            }
+        }
+        ]
+    }
+}

--- a/doc/shelly_2.5_roller_shutter.json
+++ b/doc/shelly_2.5_roller_shutter.json
@@ -23,7 +23,7 @@
                 "POSITION": {
                     "url": "?go=to_pos&roller_pos=${position_percent}"
                 },
-                "wh-STATUS": {
+                "STATUS_POLLING": {
                     "url": "",
                     "response" : {
                         "mappings": {

--- a/setup-example.json
+++ b/setup-example.json
@@ -28,7 +28,7 @@
             "commands": {
                 "ON": "${SWITCH-1}?state=1",
                 "OFF": "${SWITCH-1}?state=0",
-                "wh-STATUS": {
+                "STATUS_POLLING": {
                     "url": "${SWITCH-1}/report",
                     "response" : {
                         "mappings": {
@@ -169,7 +169,7 @@
                 "POSITION": {
                     "url": "roller/0?go=to_pos&roller_pos=${position_percent}"
                 },
-                "wh-STATUS": {
+                "STATUS_POLLING": {
                     "url": "",
                     "response" : {
                         "mappings": {

--- a/setup-example.json
+++ b/setup-example.json
@@ -27,7 +27,17 @@
             "friendly_name": "Simple switch 1",
             "commands": {
                 "ON": "${SWITCH-1}?state=1",
-                "OFF": "${SWITCH-1}?state=0"
+                "OFF": "${SWITCH-1}?state=0",
+                "wh-STATUS": {
+                    "url": "${SWITCH-1}/report",
+                    "response" : {
+                        "mappings": {
+                            "state_bool": ".relay",
+                            "power": ".power",
+                            "temperature_c": ".temperature"
+                        }
+                    }
+                }
             }
         },
         {
@@ -142,7 +152,7 @@
         "blind" : [
         {
             "entity_id": "webhook.blind.1",
-            "friendly_name": "Blind office",
+            "friendly_name": "Shelly 2.5 roller shutter",
             "attributes": {
                 "invert_position": true
             },
@@ -158,6 +168,14 @@
                 },
                 "POSITION": {
                     "url": "roller/0?go=to_pos&roller_pos=${position_percent}"
+                },
+                "wh-STATUS": {
+                    "url": "",
+                    "response" : {
+                        "mappings": {
+                            "position_percent": ".current_pos"
+                        }
+                    }
                 }
             }
         }

--- a/setup-example.json
+++ b/setup-example.json
@@ -2,6 +2,7 @@
     "_comment": "Test configuration for https://requestbin.com/r/en7n3554s0rbk",
     "base_url": "https://en7n3554s0rbk.x.pipedream.net/${ROOT}",
     "ssl_ignore": false,
+    "status_polling": 30,
     "placeholders": {
         "TOKEN": "secret123",
         "ROOT": "test",

--- a/src/blindhandler.cpp
+++ b/src/blindhandler.cpp
@@ -29,7 +29,7 @@ static Q_LOGGING_CATEGORY(CLASS_LC, "yio.intg.webhook.blind");
 BlindHandler::BlindHandler(const QString &baseUrl, QObject *parent) : EntityHandler("switch", baseUrl, parent) {}
 
 WebhookRequest *BlindHandler::createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
-                                                   const QVariantMap &placeholders, const QVariant &param) {
+                                                   const QVariantMap &placeholders, const QVariant &param) const {
     QString         feature;
     QVariantMap     parameters(placeholders);
     BlindInterface *blindInterface = static_cast<BlindInterface *>(entity->getSpecificInterface());

--- a/src/blindhandler.cpp
+++ b/src/blindhandler.cpp
@@ -56,7 +56,7 @@ WebhookRequest *BlindHandler::createCommandRequest(const QString &entityId, Enti
             break;
         default:
             qCWarning(CLASS_LC) << "Unsupported command:" << command;
-            return Q_NULLPTR;
+            return nullptr;
     }
 
     qCDebug(CLASS_LC()) << entity->friendly_name() << "command:" << feature << ", parameter:" << param;

--- a/src/blindhandler.cpp
+++ b/src/blindhandler.cpp
@@ -28,8 +28,8 @@ static Q_LOGGING_CATEGORY(CLASS_LC, "yio.intg.webhook.blind");
 
 BlindHandler::BlindHandler(const QString &baseUrl, QObject *parent) : EntityHandler("switch", baseUrl, parent) {}
 
-WebhookRequest *BlindHandler::prepareRequest(const QString &entityId, EntityInterface *entity, int command,
-                                             const QVariantMap &placeholders, const QVariant &param) {
+WebhookRequest *BlindHandler::createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
+                                                   const QVariantMap &placeholders, const QVariant &param) {
     QString         feature;
     QVariantMap     parameters(placeholders);
     BlindInterface *blindInterface = static_cast<BlindInterface *>(entity->getSpecificInterface());
@@ -68,8 +68,8 @@ WebhookRequest *BlindHandler::prepareRequest(const QString &entityId, EntityInte
     return createRequest(feature, entityId, parameters);
 }
 
-void BlindHandler::onReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
-                           QNetworkReply *reply) {
+void BlindHandler::commandReply(int command, EntityInterface *entity, const QVariant &param,
+                                const WebhookRequest *request, QNetworkReply *reply) {
     BlindInterface *blindInterface = static_cast<BlindInterface *>(entity->getSpecificInterface());
 
     int state = -1;
@@ -101,14 +101,7 @@ void BlindHandler::onReply(int command, EntityInterface *entity, const QVariant 
     updateEntity(entity, state, position, false);  // no conversion of UI position!
 
     if (reply->error() == QNetworkReply::NoError) {
-        QVariantMap values;
-        int         count = retrieveResponseValues(reply, request->webhookCommand->responseMappings, &values);
-        if (count > 0) {
-            if (CLASS_LC().isDebugEnabled()) {
-                qCDebug(CLASS_LC) << "Extracted response values:" << values;
-            }
-            updateEntity(entity, values);
-        }
+        handleResponseData(entity, request, reply);
     } else {
         // revert entity / UI state in case request failed
         // TODO(zehnm) enhance EntityInterface with refresh() option to simplify entity state -> UI reset.

--- a/src/blindhandler.h
+++ b/src/blindhandler.h
@@ -32,21 +32,22 @@ class BlindHandler : public EntityHandler {
 
     // EntityHandler interface
  public:
-    WebhookRequest *prepareRequest(const QString &entityId, EntityInterface *entity, int command,
-                                   const QVariantMap &placeholders, const QVariant &param) override;
+    WebhookRequest *createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
+                                         const QVariantMap &placeholders, const QVariant &param) override;
 
-    void onReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
-                 QNetworkReply *reply) override;
+    void commandReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
+                      QNetworkReply *reply) override;
 
  protected:
-  const QLoggingCategory &logCategory() const override;
+    const QLoggingCategory &logCategory() const override;
+
+    void updateEntity(EntityInterface *entity, const QVariantMap &placeholders) override;
 
  private:
     bool isConvertPosition(const QString &entityId);
 
-    int convertPosition(int position) const;
+    int  convertPosition(int position) const;
     void setPlaceholderValues(QVariantMap *placeholders, int state, int position) const;
-    void updateEntity(EntityInterface *entity, const QVariantMap &placeholders);
 
     void updateEntity(EntityInterface *entity, int state, int position, bool convert = true);
 };

--- a/src/blindhandler.h
+++ b/src/blindhandler.h
@@ -33,7 +33,7 @@ class BlindHandler : public EntityHandler {
     // EntityHandler interface
  public:
     WebhookRequest *createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
-                                         const QVariantMap &placeholders, const QVariant &param) override;
+                                         const QVariantMap &placeholders, const QVariant &param) const override;
 
     void commandReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
                       QNetworkReply *reply) override;

--- a/src/entityhandler.cpp
+++ b/src/entityhandler.cpp
@@ -176,13 +176,13 @@ WebhookRequest *EntityHandler::createRequest(const QString &commandName, const Q
                                              const QVariantMap &placeholders) const {
     if (!m_webhookEntities.contains(entityId)) {
         qCWarning(logCategory()) << "Entity not found:" << entityId;
-        return Q_NULLPTR;
+        return nullptr;
     }
 
     WebhookEntity *entity = m_webhookEntities.value(entityId);
     if (!entity->commands.contains(commandName)) {
         qCWarning(logCategory()) << "Command" << commandName << "not defined for entity:" << entityId;
-        return Q_NULLPTR;
+        return nullptr;
     }
     WebhookCommand *command = entity->commands.value(commandName);
 

--- a/src/entityhandler.cpp
+++ b/src/entityhandler.cpp
@@ -28,6 +28,8 @@
 
 #include "jsonpath.h"
 
+const QString EntityHandler::STATUS_COMMAND = "wh-STATUS";
+
 EntityHandler::EntityHandler(const QString &entityType, const QString &baseUrl, QObject *parent)
     : QObject(parent), m_entityType(entityType), m_baseUrl(baseUrl) {}
 
@@ -44,7 +46,7 @@ int EntityHandler::readEntities(const QVariantList &entityCfgList, const QVarian
             iter.next();
             QString  feature = iter.key();
             QVariant featureCfg = iter.value();
-            if (feature == "STATUS") {
+            if (feature == STATUS_COMMAND) {
                 // TODO(zehnm) handle STATUS
             } else {
                 entity->supportedFeatures.append(feature);
@@ -100,11 +102,11 @@ bool EntityHandler::hasStatusCommand(const QString &entityId) const {
     if (!entity) {
         return false;
     }
-    return entity->commands.contains("STATUS");
+    return entity->commands.contains(STATUS_COMMAND);
 }
 
 WebhookRequest *EntityHandler::createStatusRequest(const QString &entityId, const QVariantMap &placeholders) const {
-    return createRequest("STATUS", entityId, placeholders);
+    return createRequest(STATUS_COMMAND, entityId, placeholders);
 }
 
 void EntityHandler::statusReply(EntityInterface *entity, const WebhookRequest *request, QNetworkReply *reply) {

--- a/src/entityhandler.cpp
+++ b/src/entityhandler.cpp
@@ -91,6 +91,18 @@ int EntityHandler::readEntities(const QVariantList &entityCfgList, const QVarian
     return count;
 }
 
+bool EntityHandler::hasStatusCommand(const QString &entityId) {
+    WebhookEntity *entity = m_webhookEntities.value(entityId);
+    if (!entity) {
+        return false;
+    }
+    return entity->commands.contains("STATUS");
+}
+
+WebhookRequest *EntityHandler::createStatusRequest(const QString &entityId, const QVariantMap &placeholders) {
+    return createRequest("STATUS", entityId, placeholders);
+}
+
 int EntityHandler::convertBrightnessToPercentage(float value) const {
     // TODO(zehnm) implement scaling option
     return static_cast<int>(round(value / 255 * 100));

--- a/src/entityhandler.cpp
+++ b/src/entityhandler.cpp
@@ -28,7 +28,7 @@
 
 #include "jsonpath.h"
 
-const QString EntityHandler::STATUS_COMMAND = "wh-STATUS";
+const QString EntityHandler::STATUS_COMMAND = "STATUS_POLLING";
 
 EntityHandler::EntityHandler(const QString &entityType, const QString &baseUrl, QObject *parent)
     : QObject(parent), m_entityType(entityType), m_baseUrl(baseUrl) {}

--- a/src/entityhandler.h
+++ b/src/entityhandler.h
@@ -26,6 +26,7 @@
 #include <QList>
 #include <QLoggingCategory>
 #include <QMap>
+#include <QMapIterator>
 #include <QMetaEnum>
 #include <QNetworkReply>
 #include <QObject>
@@ -57,16 +58,21 @@ class EntityHandler : public QObject {
     QList<WebhookEntity*> getEntities() const { return m_webhookEntities.values(); }
 
     /**
+     * @brief Returns a Java-style const iterator of the created webhook entities.
+     */
+    QMapIterator<QString, WebhookEntity*> entityIter() const;
+
+    /**
      * @brief Returns true if the given entity supports status requests.
      */
-    bool hasStatusCommand(const QString& entityId);
+    bool hasStatusCommand(const QString& entityId) const;
 
     /**
      * @brief Creates an internal status update request for the given entity identifier.
      * @return A newly created WebhookRequest object which must be deleted by the caller, or null if the entity does not
      * support status requests.
      */
-    WebhookRequest* createStatusRequest(const QString& entityId, const QVariantMap& placeholders);
+    WebhookRequest* createStatusRequest(const QString& entityId, const QVariantMap& placeholders) const;
 
     /**
      * @brief Handles the internal QNetworkReply from the given status request.
@@ -87,7 +93,7 @@ class EntityHandler : public QObject {
      * not be created.
      */
     virtual WebhookRequest* createCommandRequest(const QString& entityId, EntityInterface* entity, int command,
-                                                 const QVariantMap& placeholders, const QVariant& param) = 0;
+                                                 const QVariantMap& placeholders, const QVariant& param) const = 0;
 
     /**
      * @brief Handles the QNetworkReply from the given webhook request.

--- a/src/entityhandler.h
+++ b/src/entityhandler.h
@@ -49,6 +49,9 @@ class EntityHandler : public QObject {
 
     QList<WebhookEntity*> getEntities() const { return m_webhookEntities.values(); }
 
+    bool hasStatusCommand(const QString& entityId);
+    WebhookRequest* createStatusRequest(const QString& entityId, const QVariantMap& placeholders);
+
     virtual WebhookRequest* prepareRequest(const QString& entityId, EntityInterface* entity, int command,
                                            const QVariantMap& placeholders, const QVariant& param) = 0;
 

--- a/src/entityhandler.h
+++ b/src/entityhandler.h
@@ -134,6 +134,11 @@ class EntityHandler : public QObject {
     }
 
  protected:
+    /**
+     * @brief Internal status command identifier
+     */
+    static const QString STATUS_COMMAND;
+
     QString m_entityType;
     QString m_baseUrl;
 

--- a/src/jsonpath.cpp
+++ b/src/jsonpath.cpp
@@ -45,7 +45,7 @@ QVariant JsonPath::value(const QString &path, QVariant defaultValue) const {
 
     QRegularExpression arrayRegEx("(\\w*)\\[(\\d+)\\]$");
 
-    for (auto segment : segments) {
+    for (const QString &segment : qAsConst(segments)) {
         QRegularExpressionMatch match = arrayRegEx.match(segment);
         if (match.hasMatch()) {
             QString objectName = match.captured(1);

--- a/src/lighthandler.cpp
+++ b/src/lighthandler.cpp
@@ -68,7 +68,7 @@ WebhookRequest *LightHandler::createCommandRequest(const QString &entityId, Enti
         }
         default:
             qCWarning(CLASS_LC) << "Unsupported command:" << command;
-            return Q_NULLPTR;
+            return nullptr;
     }
 
     qCDebug(CLASS_LC()) << entity->friendly_name() << "command:" << feature << ", parameter:" << param;

--- a/src/lighthandler.cpp
+++ b/src/lighthandler.cpp
@@ -29,7 +29,7 @@ static Q_LOGGING_CATEGORY(CLASS_LC, "yio.intg.webhook.light");
 LightHandler::LightHandler(const QString &baseUrl, QObject *parent) : EntityHandler("light", baseUrl, parent) {}
 
 WebhookRequest *LightHandler::createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
-                                                   const QVariantMap &placeholders, const QVariant &param) {
+                                                   const QVariantMap &placeholders, const QVariant &param) const {
     QString         feature;
     QVariantMap     parameters(placeholders);
     LightInterface *lightInterface = static_cast<LightInterface *>(entity->getSpecificInterface());

--- a/src/lighthandler.cpp
+++ b/src/lighthandler.cpp
@@ -28,8 +28,8 @@ static Q_LOGGING_CATEGORY(CLASS_LC, "yio.intg.webhook.light");
 
 LightHandler::LightHandler(const QString &baseUrl, QObject *parent) : EntityHandler("light", baseUrl, parent) {}
 
-WebhookRequest *LightHandler::prepareRequest(const QString &entityId, EntityInterface *entity, int command,
-                                             const QVariantMap &placeholders, const QVariant &param) {
+WebhookRequest *LightHandler::createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
+                                                   const QVariantMap &placeholders, const QVariant &param) {
     QString         feature;
     QVariantMap     parameters(placeholders);
     LightInterface *lightInterface = static_cast<LightInterface *>(entity->getSpecificInterface());
@@ -78,8 +78,8 @@ WebhookRequest *LightHandler::prepareRequest(const QString &entityId, EntityInte
     return createRequest(feature, entityId, parameters);
 }
 
-void LightHandler::onReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
-                           QNetworkReply *reply) {
+void LightHandler::commandReply(int command, EntityInterface *entity, const QVariant &param,
+                                const WebhookRequest *request, QNetworkReply *reply) {
     LightInterface *lightInterface = static_cast<LightInterface *>(entity->getSpecificInterface());
 
     // reflect intended state in entity. This is also required in case of a failed request!
@@ -115,14 +115,7 @@ void LightHandler::onReply(int command, EntityInterface *entity, const QVariant 
     updateEntity(entity, state, color, brightness, colorTemp);
 
     if (reply->error() == QNetworkReply::NoError) {
-        QVariantMap values;
-        int         count = retrieveResponseValues(reply, request->webhookCommand->responseMappings, &values);
-        if (count > 0) {
-            if (CLASS_LC().isDebugEnabled()) {
-                qCDebug(CLASS_LC) << "Extracted response values:" << values;
-            }
-            updateEntity(entity, values);
-        }
+        handleResponseData(entity, request, reply);
     } else {
         // revert entity / UI state in case request failed
         // TODO(zehnm) enhance EntityInterface with refresh() option to simplify entity state -> UI reset.

--- a/src/lighthandler.h
+++ b/src/lighthandler.h
@@ -35,7 +35,7 @@ class LightHandler : public EntityHandler {
     // EntityHandler interface
  public:
     WebhookRequest *createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
-                                         const QVariantMap &placeholders, const QVariant &param) override;
+                                         const QVariantMap &placeholders, const QVariant &param) const override;
 
     void commandReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
                       QNetworkReply *reply) override;

--- a/src/lighthandler.h
+++ b/src/lighthandler.h
@@ -34,20 +34,20 @@ class LightHandler : public EntityHandler {
 
     // EntityHandler interface
  public:
-    WebhookRequest *prepareRequest(const QString &entityId, EntityInterface *entity, int command,
-                                   const QVariantMap &placeholders, const QVariant &param) override;
+    WebhookRequest *createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
+                                         const QVariantMap &placeholders, const QVariant &param) override;
 
-    void onReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
-                 QNetworkReply *reply) override;
+    void commandReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
+                      QNetworkReply *reply) override;
 
  protected:
-  const QLoggingCategory &logCategory() const override;
+    const QLoggingCategory &logCategory() const override;
+
+    void updateEntity(EntityInterface *entity, const QVariantMap &placeholders) override;
 
  private:
     void setPlaceholderValues(QVariantMap *placeholders, int state, const QColor &color, int brightness,
                               int colorTemp) const;
-
-    void updateEntity(EntityInterface *entity, const QVariantMap &placeholders);
 
     void updateEntity(EntityInterface *entity, int state, const QVariant &color, int brightness, int colorTemp);
 };

--- a/src/setup-schema.json
+++ b/src/setup-schema.json
@@ -91,6 +91,13 @@
             "description": "Set true if you want to skip SSL verification",
             "default": false
         },
+        "status_polling": {
+            "type": "integer",
+            "minimum": 0,
+            "title": "Status polling intervall (sec)",
+            "description": "0 disables polling",
+            "default": 30
+        },
         "placeholders": {
             "type": "object",
             "title": "Key value placeholders for url, headers, body",

--- a/src/switchhandler.cpp
+++ b/src/switchhandler.cpp
@@ -28,8 +28,8 @@ static Q_LOGGING_CATEGORY(CLASS_LC, "yio.intg.webhook.switch");
 
 SwitchHandler::SwitchHandler(const QString &baseUrl, QObject *parent) : EntityHandler("switch", baseUrl, parent) {}
 
-WebhookRequest *SwitchHandler::prepareRequest(const QString &entityId, EntityInterface *entity, int command,
-                                              const QVariantMap &placeholders, const QVariant &param) {
+WebhookRequest *SwitchHandler::createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
+                                                    const QVariantMap &placeholders, const QVariant &param) {
     Q_UNUSED(entity)
     Q_UNUSED(param)
 
@@ -47,8 +47,8 @@ WebhookRequest *SwitchHandler::prepareRequest(const QString &entityId, EntityInt
     return Q_NULLPTR;
 }
 
-void SwitchHandler::onReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
-                            QNetworkReply *reply) {
+void SwitchHandler::commandReply(int command, EntityInterface *entity, const QVariant &param,
+                                 const WebhookRequest *request, QNetworkReply *reply) {
     Q_UNUSED(param)
 
     int oldState = entity->state();
@@ -58,14 +58,7 @@ void SwitchHandler::onReply(int command, EntityInterface *entity, const QVariant
     }
 
     if (reply->error() == QNetworkReply::NoError) {
-        QVariantMap values;
-        int         count = retrieveResponseValues(reply, request->webhookCommand->responseMappings, &values);
-        if (count > 0) {
-            if (CLASS_LC().isDebugEnabled()) {
-                qCDebug(CLASS_LC) << "Extracted response values:" << values;
-            }
-            updateEntity(entity, values);
-        }
+        handleResponseData(entity, request, reply);
     } else {
         // revert entity / UI state in case request failed
         entity->setState(oldState);

--- a/src/switchhandler.cpp
+++ b/src/switchhandler.cpp
@@ -29,7 +29,7 @@ static Q_LOGGING_CATEGORY(CLASS_LC, "yio.intg.webhook.switch");
 SwitchHandler::SwitchHandler(const QString &baseUrl, QObject *parent) : EntityHandler("switch", baseUrl, parent) {}
 
 WebhookRequest *SwitchHandler::createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
-                                                    const QVariantMap &placeholders, const QVariant &param) {
+                                                    const QVariantMap &placeholders, const QVariant &param) const {
     Q_UNUSED(entity)
     Q_UNUSED(param)
 

--- a/src/switchhandler.cpp
+++ b/src/switchhandler.cpp
@@ -44,7 +44,7 @@ WebhookRequest *SwitchHandler::createCommandRequest(const QString &entityId, Ent
             qCWarning(CLASS_LC) << "Unsupported command:" << command;
     }
 
-    return Q_NULLPTR;
+    return nullptr;
 }
 
 void SwitchHandler::commandReply(int command, EntityInterface *entity, const QVariant &param,

--- a/src/switchhandler.cpp
+++ b/src/switchhandler.cpp
@@ -84,7 +84,7 @@ void SwitchHandler::updateEntity(EntityInterface *entity, const QVariantMap &pla
     if (placeholders.contains("power")) {
         int power = placeholders.value("power").toInt();
         if (power >= 0 && entity->isSupported(SwitchDef::F_POWER)) {
-            qCDebug(CLASS_LC()) << "Update" << entity->friendly_name() << "power:" << state;
+            qCDebug(CLASS_LC()) << "Update" << entity->friendly_name() << "power:" << power;
             entity->updateAttrByIndex(SwitchDef::POWER, power);
         }
     }

--- a/src/switchhandler.h
+++ b/src/switchhandler.h
@@ -33,7 +33,7 @@ class SwitchHandler : public EntityHandler {
     // EntityHandler interface
  public:
     WebhookRequest *createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
-                                         const QVariantMap &placeholders, const QVariant &param) override;
+                                         const QVariantMap &placeholders, const QVariant &param) const override;
 
     void commandReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
                       QNetworkReply *reply) override;

--- a/src/switchhandler.h
+++ b/src/switchhandler.h
@@ -32,15 +32,14 @@ class SwitchHandler : public EntityHandler {
 
     // EntityHandler interface
  public:
-    WebhookRequest *prepareRequest(const QString &entityId, EntityInterface *entity, int command,
-                                   const QVariantMap &placeholders, const QVariant &param) override;
+    WebhookRequest *createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
+                                         const QVariantMap &placeholders, const QVariant &param) override;
 
-    void onReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
-                 QNetworkReply *reply) override;
+    void commandReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
+                      QNetworkReply *reply) override;
 
  protected:
     const QLoggingCategory &logCategory() const override;
 
- private:
-    void updateEntity(EntityInterface *entity, const QVariantMap &placeholders);
+    void updateEntity(EntityInterface *entity, const QVariantMap &placeholders) override;
 };

--- a/src/webhook.cpp
+++ b/src/webhook.cpp
@@ -41,7 +41,7 @@ Integration *WebhookPlugin::createIntegration(const QVariantMap &config, Entitie
 
 Webhook::Webhook(const QVariantMap &config, EntitiesInterface *entities, NotificationsInterface *notifications,
                  YioAPIInterface *api, ConfigInterface *configObj, Plugin *plugin)
-    : Integration(config, entities, notifications, api, configObj, plugin), m_statusTimer(Q_NULLPTR) {
+    : Integration(config, entities, notifications, api, configObj, plugin), m_statusTimer(nullptr) {
     if (!config.contains(Integration::OBJ_DATA)) {
         qCCritical(m_logCategory) << "Missing configuration key" << Integration::OBJ_DATA;
         return;
@@ -214,7 +214,7 @@ void Webhook::ignoreSslErrors(QNetworkReply *reply, const QList<QSslError> &erro
 void Webhook::statusUpdate() {
     // Proof of concept only! Verify if this blocks the main thread for too long. Otherwise use a processing thread.
     for (EntityHandler *handler : qAsConst(m_handlers)) {
-        QMapIterator<QString, WebhookEntity*> entityIter = handler->entityIter();
+        QMapIterator<QString, WebhookEntity *> entityIter = handler->entityIter();
         while (entityIter.hasNext()) {
             entityIter.next();
             const WebhookEntity *entity = entityIter.value();

--- a/src/webhook.h
+++ b/src/webhook.h
@@ -80,10 +80,9 @@ class Webhook : public Integration {
     void leaveStandby() override;
 
  private:
-    void addAvailableEntities(const QList<WebhookEntity*>& entities);
-    void configureProxy(const QVariantMap& proxyCfg);
-    void sendWebhookRequest(WebhookRequest* request, EntityHandler* entityHandler, EntityInterface* entity, int command,
-                            const QVariant& param);
+    void           addAvailableEntities(const QList<WebhookEntity*>& entities);
+    void           configureProxy(const QVariantMap& proxyCfg);
+    QNetworkReply* sendWebhookRequest(WebhookRequest* request);
 
  private slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     void ignoreSslErrors(QNetworkReply* reply, const QList<QSslError>& errors);

--- a/src/webhook.h
+++ b/src/webhook.h
@@ -39,7 +39,6 @@
 #include "yio-interface/entities/entityinterface.h"
 #include "yio-interface/notificationsinterface.h"
 #include "yio-interface/plugininterface.h"
-#include "yio-interface/yioapiinterface.h"
 #include "yio-plugin/integration.h"
 #include "yio-plugin/plugin.h"
 

--- a/src/webhook.h
+++ b/src/webhook.h
@@ -29,7 +29,7 @@
 #include <QObject>
 #include <QSslError>
 #include <QString>
-#include <QThread>
+#include <QTimer>
 #include <QVariantMap>
 
 #include "entityhandler.h"
@@ -80,14 +80,18 @@ class Webhook : public Integration {
     void leaveStandby() override;
 
  private:
-    void addAvailableEntities(const QList<WebhookEntity *> &entities);
+    void addAvailableEntities(const QList<WebhookEntity*>& entities);
     void configureProxy(const QVariantMap& proxyCfg);
+    void sendWebhookRequest(WebhookRequest* request, EntityHandler* entityHandler, EntityInterface* entity, int command,
+                            const QVariant& param);
 
  private slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     void ignoreSslErrors(QNetworkReply* reply, const QList<QSslError>& errors);
+    void onStatusUpdate();
 
  private:
     QNetworkAccessManager         m_networkManager;
     QMap<QString, EntityHandler*> m_handlers;
     QVariantMap                   m_placeholders;
+    QTimer*                       m_statusTimer;
 };

--- a/src/webhook.h
+++ b/src/webhook.h
@@ -87,7 +87,7 @@ class Webhook : public Integration {
 
  private slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     void ignoreSslErrors(QNetworkReply* reply, const QList<QSslError>& errors);
-    void onStatusUpdate();
+    void statusUpdate();
 
  private:
     QNetworkAccessManager         m_networkManager;

--- a/src/webhookcommand.h
+++ b/src/webhookcommand.h
@@ -28,6 +28,8 @@
 
 #include "httpmethod.h"
 
+const int COMMAND_STATUS = -999;
+
 /**
  * @brief Webhook raw command data, read from the configuration.
  */

--- a/src/webhookcommand.h
+++ b/src/webhookcommand.h
@@ -28,8 +28,6 @@
 
 #include "httpmethod.h"
 
-const int COMMAND_STATUS = -999;
-
 /**
  * @brief Webhook raw command data, read from the configuration.
  */

--- a/src/webhookrequest.h
+++ b/src/webhookrequest.h
@@ -34,8 +34,7 @@
  */
 class WebhookRequest : public QObject {
  public:
-    explicit WebhookRequest(QObject* parent = nullptr)
-        : QObject(parent), webhookCommand(Q_NULLPTR) {}
+    explicit WebhookRequest(QObject* parent = nullptr) : QObject(parent), webhookCommand(Q_NULLPTR) {}
 
  public:
     const WebhookCommand* webhookCommand;

--- a/src/webhookrequest.h
+++ b/src/webhookrequest.h
@@ -26,7 +26,6 @@
 #include <QNetworkRequest>
 #include <QObject>
 
-#include "httpmethod.h"
 #include "webhookcommand.h"
 
 /**
@@ -34,7 +33,7 @@
  */
 class WebhookRequest : public QObject {
  public:
-    explicit WebhookRequest(QObject* parent = nullptr) : QObject(parent), webhookCommand(Q_NULLPTR) {}
+    explicit WebhookRequest(QObject* parent = nullptr) : QObject(parent), webhookCommand(nullptr) {}
 
  public:
     const WebhookCommand* webhookCommand;

--- a/tests/entityhandlertest/entityhandlerimpl.h
+++ b/tests/entityhandlertest/entityhandlerimpl.h
@@ -13,7 +13,7 @@ class EntityHandlerImpl : public EntityHandler {
     // EntityHandler interface
  public:
     WebhookRequest *createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
-                                   const QVariantMap &placeholders, const QVariant &param) override {
+                                   const QVariantMap &placeholders, const QVariant &param) const override {
         Q_UNUSED(entityId)
         Q_UNUSED(entity)
         Q_UNUSED(command)

--- a/tests/entityhandlertest/entityhandlerimpl.h
+++ b/tests/entityhandlertest/entityhandlerimpl.h
@@ -12,7 +12,7 @@ class EntityHandlerImpl : public EntityHandler {
 
     // EntityHandler interface
  public:
-    WebhookRequest *prepareRequest(const QString &entityId, EntityInterface *entity, int command,
+    WebhookRequest *createCommandRequest(const QString &entityId, EntityInterface *entity, int command,
                                    const QVariantMap &placeholders, const QVariant &param) override {
         Q_UNUSED(entityId)
         Q_UNUSED(entity)
@@ -22,7 +22,7 @@ class EntityHandlerImpl : public EntityHandler {
         return Q_NULLPTR;
     }
 
-    void onReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
+    void commandReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,
                  QNetworkReply *reply) override {
         Q_UNUSED(command)
         Q_UNUSED(entity)
@@ -33,6 +33,11 @@ class EntityHandlerImpl : public EntityHandler {
 
  protected:
     const QLoggingCategory& logCategory() const override { return CLASS_LC_TEST(); }
+
+    void updateEntity(EntityInterface *entity, const QVariantMap &placeholders) override {
+        Q_UNUSED(entity)
+        Q_UNUSED(placeholders)
+    }
 
  private:
     friend TestEntityHandler;

--- a/tests/entityhandlertest/entityhandlerimpl.h
+++ b/tests/entityhandlertest/entityhandlerimpl.h
@@ -19,7 +19,7 @@ class EntityHandlerImpl : public EntityHandler {
         Q_UNUSED(command)
         Q_UNUSED(placeholders)
         Q_UNUSED(param)
-        return Q_NULLPTR;
+        return nullptr;
     }
 
     void commandReply(int command, EntityInterface *entity, const QVariant &param, const WebhookRequest *request,

--- a/webhook.pro
+++ b/webhook.pro
@@ -7,4 +7,6 @@ win32|if(unix:!cross_compile): SUBDIRS += tests
 DISTFILES += \
     dependencies.cfg \
     setup-example.json \
-    README.md
+    README.md \
+    doc/mystrom_switch.json \
+    doc/shelly_2.5_roller_shutter.json


### PR DESCRIPTION
- Enabled with internal entity command named `STATUS_POLLING`
- Only active while screen is on (non-standby)
- Polling intervall is configurable. Default: 30s
